### PR TITLE
Add Progressive Web App support

### DIFF
--- a/myviews/debug.ejs
+++ b/myviews/debug.ejs
@@ -24,6 +24,12 @@
 
   <title>Posterr Debug Page</title>
   <link rel="shortcut icon" type="image/png" href="<%=baseUrl%>/favicons/favicon.ico"/>
+  <link rel="manifest" href="<%=baseUrl%>/site.webmanifest">
+  <meta name="theme-color" content="#000000">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Posterr">
+  <link rel="apple-touch-icon" href="<%=baseUrl%>/favicons/apple-touch-icon.png">
 </head>
 
 <body>
@@ -85,5 +91,6 @@ See logs for results
       <li><%= k %>: <span class="settings"><%= keyVal %></span></li>
     <% } %> 
    </ul>
+<script src="<%=baseUrl%>/js/pwa-register.js" defer data-base-url="<%=baseUrl%>"></script>
 </body>
 </html>

--- a/myviews/footer.ejs
+++ b/myviews/footer.ejs
@@ -1,2 +1,3 @@
+<script src="<%=baseUrl%>/js/pwa-register.js" defer data-base-url="<%=baseUrl%>"></script>
 </body>
 </html>

--- a/myviews/header.ejs
+++ b/myviews/header.ejs
@@ -50,5 +50,11 @@
 
   <title>Posterr</title>
   <link rel="shortcut icon" type="image/png" href="<%=baseUrl%>/favicons/favicon.ico"/>
+  <link rel="manifest" href="<%=baseUrl%>/site.webmanifest">
+  <meta name="theme-color" content="#000000">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Posterr">
+  <link rel="apple-touch-icon" href="<%=baseUrl%>/favicons/apple-touch-icon.png">
 </head>
 <body>

--- a/myviews/logon.ejs
+++ b/myviews/logon.ejs
@@ -26,6 +26,12 @@
 
     <title>Posterr - Settings Login</title>
     <link rel="shortcut icon" type="image/png" href="<%=baseUrl%>/favicons/favicon.ico" />
+    <link rel="manifest" href="<%=baseUrl%>/site.webmanifest">
+    <meta name="theme-color" content="#000000">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="apple-mobile-web-app-title" content="Posterr">
+    <link rel="apple-touch-icon" href="<%=baseUrl%>/favicons/apple-touch-icon.png">
     <style>
 div {
   margin-left: 70px;
@@ -72,6 +78,7 @@ color: whitesmoke;
         var pwd = document.getElementById("password");
         pwd.focus();
     </script>
+    <script src="<%=baseUrl%>/js/pwa-register.js" defer data-base-url="<%=baseUrl%>"></script>
 </body>
 
 </html>

--- a/myviews/settings.ejs
+++ b/myviews/settings.ejs
@@ -30,6 +30,12 @@
 
   <title>Posterr - Settings</title>
   <link rel="shortcut icon" type="image/png" href="<%=baseUrl%>/favicons/favicon.ico" />
+  <link rel="manifest" href="<%=baseUrl%>/site.webmanifest">
+  <meta name="theme-color" content="#000000">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Posterr">
+  <link rel="apple-touch-icon" href="<%=baseUrl%>/favicons/apple-touch-icon.png">
 </head>
 
 <body>
@@ -1188,7 +1194,7 @@
 
       </div>
 
-
+  <script src="<%=baseUrl%>/js/pwa-register.js" defer data-base-url="<%=baseUrl%>"></script>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "scripts": "public/js/*.js",
     "assets": [
       "public/js/*.map",
+      "public/service-worker.js",
+      "public/site.webmanifest",
       "public/css/**/*",
       "public/favicons/**/*",
       "public/images/**/*",

--- a/public/js/pwa-register.js
+++ b/public/js/pwa-register.js
@@ -1,0 +1,24 @@
+(function registerPosterrPwa() {
+  if (!("serviceWorker" in navigator)) {
+    return;
+  }
+
+  function normalizeBaseUrl(value) {
+    if (!value || value === "/") {
+      return "";
+    }
+    return value.endsWith("/") ? value.slice(0, -1) : value;
+  }
+
+  const currentScript =
+    document.currentScript || document.querySelector('script[src$="/js/pwa-register.js"]');
+  const baseUrl = normalizeBaseUrl(currentScript && currentScript.getAttribute("data-base-url"));
+  const serviceWorkerUrl = `${baseUrl}/service-worker.js`;
+  const scope = `${baseUrl || ""}/`;
+
+  window.addEventListener("load", function () {
+    navigator.serviceWorker.register(serviceWorkerUrl, { scope: scope }).catch(function () {
+      // Registration failures should not impact normal app usage.
+    });
+  });
+})();

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,86 @@
+const CACHE_NAME = "posterr-v1";
+const STATIC_CACHE = "posterr-static-v1";
+
+function getScopePath() {
+  const scopeUrl = new URL(self.registration.scope);
+  const scopePath = scopeUrl.pathname.replace(/\/$/, "");
+  return scopePath === "/" ? "" : scopePath;
+}
+
+function withScope(path) {
+  return `${getScopePath()}${path}`;
+}
+
+self.addEventListener("install", (event) => {
+  const coreAssets = [
+    "/",
+    "/css/bootstrap.min.css",
+    "/css/font-awesome.min.css",
+    "/css/styles.css",
+    "/js/jquery-3.3.1.slim.min.js",
+    "/js/bootstrap.min.js",
+    "/images/no-poster-available.png",
+    "/favicons/favicon.ico",
+    "/favicons/android-chrome-192x192.png",
+    "/favicons/android-chrome-512x512.png",
+    "/site.webmanifest"
+  ].map(withScope);
+
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(coreAssets)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME && key !== STATIC_CACHE)
+            .map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request;
+  if (request.method !== "GET") {
+    return;
+  }
+
+  const requestUrl = new URL(request.url);
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
+
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, responseClone));
+          return response;
+        })
+        .catch(() => caches.match(request).then((cached) => cached || caches.match(withScope("/"))))
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      const networkFetch = fetch(request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(STATIC_CACHE).then((cache) => cache.put(request, responseClone));
+          return response;
+        })
+        .catch(() => cached);
+
+      return cached || networkFetch;
+    })
+  );
+});

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "Posterr",
+  "short_name": "Posterr",
+  "description": "A digital display for your media",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "favicons/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "favicons/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
* Add initial support for Progressive Web Apps
* Primarily Allows iOS Devices to display Poster properly in full screen
* Setups up a very conservative offline cache (not really useful in the Posterrs case anyway)
* Needs deeper testing