### PR TITLE
Update plex.js

### DIFF
--- a/classes/mediaservers/plex.js
+++ b/classes/mediaservers/plex.js
@@ -477,7 +477,7 @@ class Plex {
           // apply filter checks
           if(filterRemote=='true' && medCard.playerLocal == false) okToAdd = true;
           if(filterLocal=='true' && medCard.playerLocal == true) okToAdd = true;
-          if(users.length > 0 && users.includes(md.User.title.toLowerCase())==false && users[0] !== "") okToAdd = false;
+          if(users.length > 0 && !util.isEmpty(md.User.title) && users.includes(md.User.title.toLowerCase())==false && users[0] !== "") okToAdd = false;
           if(devices.length > 0 && !util.isEmpty(medCard.playerDevice) && devices.includes(medCard.playerDevice.toLowerCase())==false && devices[0] !== "") okToAdd = false;
           if(excludeLibs !== undefined && excludeLibs !== "" && excludeLibs.includes(md.librarySectionTitle)) { 
             //console.log('Now Screening - Excluded library:', md.librarySectionTitle);

--- a/classes/mediaservers/plex.js
+++ b/classes/mediaservers/plex.js
@@ -477,7 +477,7 @@ class Plex {
           // apply filter checks
           if(filterRemote=='true' && medCard.playerLocal == false) okToAdd = true;
           if(filterLocal=='true' && medCard.playerLocal == true) okToAdd = true;
-          if(users.length > 0 && !util.isEmpty(md.User.title) && users.includes(md.User.title.toLowerCase())==false && users[0] !== "") okToAdd = false;
+          if(users.length > 0 && md.User.title !== undefined && users.includes(md.User.title.toLowerCase())==false && users[0] !== "") okToAdd = false;
           if(devices.length > 0 && !util.isEmpty(medCard.playerDevice) && devices.includes(medCard.playerDevice.toLowerCase())==false && devices[0] !== "") okToAdd = false;
           if(excludeLibs !== undefined && excludeLibs !== "" && excludeLibs.includes(md.librarySectionTitle)) { 
             //console.log('Now Screening - Excluded library:', md.librarySectionTitle);


### PR DESCRIPTION
Adding a check to see if the `User.title` field ends up undefined, and prevent that from causing an error when checking user filters.

This fixes an issue I was having where the `md.User.title.toLowerCase()` would throw an error due to the value being undefined.

I think this is a fair defensive check since it is similar to the one on the follow line for checking on the value of `medCard.playerDevice`