### PR TITLE
Fix Plex HTTPS option forwarding

### DIFF
--- a/index.js
+++ b/index.js
@@ -478,7 +478,7 @@ async function loadNowScreening() {
 
   // load MediaServer(s) (switch statement for different server settings server option - TODO)
   let ms = new pms({
-    plexHTTPS: loadedSettings.plexHTTPS,
+    HTTPS: loadedSettings.plexHTTPS,
     plexIP: loadedSettings.plexIP,
     plexPort: loadedSettings.plexPort,
     plexToken: loadedSettings.plexToken,
@@ -841,7 +841,7 @@ async function loadOnDemand() {
 
   // load MediaServer(s) (switch statement for different server settings server option - TODO)
   let ms = new pms({
-    plexHTTPS: loadedSettings.plexHTTPS,
+    HTTPS: loadedSettings.plexHTTPS,
     plexIP: loadedSettings.plexIP,
     plexPort: loadedSettings.plexPort,
     plexToken: loadedSettings.plexToken,


### PR DESCRIPTION
## Summary

- pass the configured Plex HTTPS setting using the `HTTPS` property expected by the Plex media-server constructor
- update both the Now Screening and On-Demand client creation paths

## Root cause

`index.js` passed the setting as `plexHTTPS`, while `classes/mediaservers/plex.js` destructures a property named `HTTPS`. The mismatch left `HTTPS` undefined, so `plex-api` could fall back to HTTP even when secure Plex connections were configured, causing requests to fail against servers requiring HTTPS.

## Behavior

This preserves the existing setting value and only corrects the property name used to forward it. No coercion or unrelated behavior is changed.

## Validation

- `node --check index.js`
- `node --check classes/mediaservers/plex.js`
- verified both constructor call sites use `HTTPS: loadedSettings.plexHTTPS`
- verified no stale `plexHTTPS: loadedSettings.plexHTTPS` call sites remain