### PR TITLE
Fix device filter being ignored (missing await on util.isEmpty)

### DIFF
--- a/classes/mediaservers/plex.js
+++ b/classes/mediaservers/plex.js
@@ -478,7 +478,7 @@ class Plex {
           if(filterRemote=='true' && medCard.playerLocal == false) okToAdd = true;
           if(filterLocal=='true' && medCard.playerLocal == true) okToAdd = true;
           if(users.length > 0 && users.includes(md.User.title.toLowerCase())==false && users[0] !== "") okToAdd = false;
-          if(devices.length > 0 && !util.isEmpty(medCard.playerDevice) && devices.includes(medCard.playerDevice.toLowerCase())==false && devices[0] !== "") okToAdd = false;
+          if(devices.length > 0 && !(await util.isEmpty(medCard.playerDevice)) && devices.includes(medCard.playerDevice.toLowerCase())==false && devices[0] !== "") okToAdd = false;
           if(excludeLibs !== undefined && excludeLibs !== "" && excludeLibs.includes(md.librarySectionTitle)) { 
             //console.log('Now Screening - Excluded library:', md.librarySectionTitle);
             okToAdd = false;


### PR DESCRIPTION
Fixes #283 — "Filter by device(s) no longer filtering".

### Cause

`utility.isEmpty()` is declared `async`, so it always returns a **Promise**, which is always truthy. The guard added in 3f3bab9 calls it without `await`:

```js
if(devices.length > 0 && !util.isEmpty(medCard.playerDevice) && ...) okToAdd = false;
```

`!util.isEmpty(...)` therefore evaluates to `false` for *every* session, so the whole condition short-circuits and `okToAdd` is never set to `false` by the device filter. Result: all devices are shown regardless of the "Filter by device(s)" setting — matching the reports that rolling back to v1.21.9 (before that commit) restores correct behaviour.

Quick demonstration of the underlying behaviour:

```
!isEmpty("Shield")           -> false   // Promise is truthy
!isEmpty("")                 -> false
!(await isEmpty("Shield"))   -> true    // correct
```

### Fix

Await the call, matching how `util.isEmpty` is used everywhere else in `plex.js` (e.g. lines 274, 321, 736). This is the only unawaited call site in the codebase.

```js
if(devices.length > 0 && !(await util.isEmpty(medCard.playerDevice)) && ...) okToAdd = false;
```

The surrounding code is already inside an `async` reduce callback, so `await` is valid here. The null-safety intent of the original commit is preserved: sessions with no `Player.title` still skip the device check instead of throwing on `.toLowerCase()`.
